### PR TITLE
CI and release configuration

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.12.5
+
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# install dependencies
+RUN apt-get update \
+  && apt-get install -y curl \
+  && apt-get install -y mingw-w64 \
+  && apt-get install -y zip \
+  && curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh \
+  && bash nodesource_setup.sh \
+  && apt-get install nodejs \
+  && apt-get -y autoclean
+
+# add global node modules to path
+ENV PATH="/usr/lib/node_modules/yarn/bin:${PATH}"
+
+# install yarn
+RUN npm install -g yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,283 @@
+version: 2.1
+
+checkout-linux: &checkout-linux
+  attach_workspace:
+    at: /root
+
+jobs:
+  persist-checkout:
+    docker:
+      - image: python
+    steps:
+      - checkout
+      - run:
+          name: clean up git
+          command: |
+            rm -rf .git
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - project
+
+  unit-test:
+    docker:
+      - image: textile/builder:1.12.5
+    steps:
+      - *checkout-linux
+      - restore_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}-{{ arch }}
+      - run:
+          name: cache mods
+          command: |
+            go mod download
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}-{{ arch }}
+          paths:
+            - /go/pkg/mod
+      - run:
+          name: run tests
+          command: |
+            make test
+
+  build-ios-framework:
+    macos:
+      xcode: '10.2.1'
+    environment:
+      GOPATH: /Users/distiller/go
+      GOROOT: /Users/distiller/gosrc/go
+    steps:
+      - checkout
+      - run:
+          name: install golang
+          command: |
+            export GOROOT=/usr/local/go
+            export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+            curl -L -o go1.12.5.darwin-amd64.tar.gz https://dl.google.com/go/go1.12.5.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.12.5.darwin-amd64.tar.gz
+            cd ~ && mkdir gosrc && cd gosrc
+            git clone https://github.com/textileio/go.git && cd go
+            git checkout sander/ptrace-hackery
+            cd src && ./all.bash
+      - restore_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}-{{ arch }}
+      - run:
+          name: cache mods
+          command: |
+            export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+            go mod download
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}-{{ arch }}
+          paths:
+            - ~/go/pkg/mod
+      - run:
+          name: build ios framework
+          command: |
+            export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+            go mod vendor
+            mkdir -p ~/go/src/github.com/berty
+            cd ~ && mv project go/src/github.com/berty/gomobile-ipfs
+            cd ~/go/src/github.com/berty/gomobile-ipfs
+            export GO111MODULE=off
+            go get golang.org/x/mobile/cmd/...
+            make build.ios
+      - run:
+          name: collect artifacts
+          command: |
+            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
+            if [ "${CIRCLE_TAG}" != "" ]; then
+                VERSION=${CIRCLE_TAG}
+            fi
+            OUT=~/dist/ios_framework
+            mkdir -p ${OUT}
+            cd ~/go/src/github.com/berty/gomobile-ipfs/build/ios
+            tar -czvf gomobile-ipfs_${VERSION}_ios-framework.tar.gz Mobile.framework
+            mv gomobile-ipfs_${VERSION}_ios-framework.tar.gz ${OUT}/
+      - persist_to_workspace:
+          root: ~/dist
+          paths:
+            - ios_framework
+      - store_artifacts:
+          path: ~/dist/ios_framework
+
+  build-android-aar:
+    docker:
+      - image: circleci/android:api-28-ndk
+    environment:
+      GOROOT: /usr/local/go
+      GOPATH: /home/circleci/go
+    steps:
+      - checkout
+      - run:
+          name: install golang
+          command: |
+            wget https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.12.5.linux-amd64.tar.gz
+            mkdir -p $GOPATH/bin
+      - restore_cache:
+          key: go-mod-v1-android-{{ checksum "go.sum" }}-{{ arch }}
+      - run:
+          name: cache mods
+          command: |
+            export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+            go mod download
+      - save_cache:
+          key: go-mod-v1-android-{{ checksum "go.sum" }}-{{ arch }}
+          paths:
+            - /go/pkg/mod
+      - run:
+          name: install tools
+          command: |
+            sdkmanager --licenses
+            echo y | sdkmanager "build-tools;28.0.3"
+            echo y | sdkmanager "platforms;android-28"
+            sdkmanager 'ndk-bundle'
+      - run:
+          name: build android framework
+          command: |
+            export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+            go mod vendor
+            mkdir -p ~/go/src/github.com/berty
+            cd ~ && mv project go/src/github.com/berty/gomobile-ipfs
+            cd ~/go/src/github.com/berty/gomobile-ipfs
+            export GO111MODULE=off
+            go get golang.org/x/mobile/cmd/...
+            make build.android
+      - run:
+          name: collect artifacts
+          command: |
+            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
+            if [ "${CIRCLE_TAG}" != "" ]; then
+                VERSION=${CIRCLE_TAG}
+            fi
+            OUT=~/dist/android_aar
+            mkdir -p ${OUT}
+            cd ~/go/src/github.com/berty/gomobile-ipfs/build/android
+            tar -czvf gomobile-ipfs_${VERSION}_android-aar.tar.gz ipfs.aar
+            mv gomobile-ipfs_${VERSION}_android-aar.tar.gz ${OUT}/
+      - persist_to_workspace:
+          root: ~/go/src/github.com/berty/gomobile-ipfs/build/android
+          paths:
+            - ipfs.aar
+      - persist_to_workspace:
+          root: ~/dist
+          paths:
+            - android_aar
+      - store_artifacts:
+          path: ~/dist/android_aar
+
+  release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - *checkout-linux
+      - deploy:
+          name: release all
+          command: |
+            mkdir -p ~/dist
+            mv ~/ios_framework/* ~/dist/
+            mv ~/android_aar/* ~/dist/
+            PRE=$(echo "${CIRCLE_TAG}" | grep "rc" || true)
+            if [ "${PRE}" != "" ]; then
+                ghr -prerelease -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ~/dist/
+            else
+                ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ~/dist/
+            fi
+
+  publish-cocoapod:
+    macos:
+      xcode: '10.2.1'
+    steps:
+      - checkout
+      - run:
+          name: Fetch CocoaPods Specs
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: update podspec
+          working_directory: release
+          command: |
+            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
+            if [ "${CIRCLE_TAG}" != "" ]; then
+                VERSION=${CIRCLE_TAG}
+                VERSION=$(echo $VERSION | cut -c 2-)
+            fi
+            sed -i.bak "s/<version>/${VERSION}/g" gomobile-ipfs.podspec
+            pod trunk push gomobile-ipfs.podspec --allow-warnings
+
+  publish-aar:
+    docker:
+      - image: circleci/android:api-28-ndk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: publish artifacts
+          working_directory: release
+          command: |
+            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
+            if [ "${CIRCLE_TAG}" != "" ]; then
+                VERSION=${CIRCLE_TAG}
+                VERSION=$(echo $VERSION | cut -c 2-)
+            fi
+            sed "s/<VERSION>/${VERSION}/g" gomobile-ipfs-template.pom > gomobile-ipfs-${VERSION}.pom
+            cp ~/ipfs.aar gomobile-ipfs-${VERSION}.aar
+            curl -i -X PUT -u ${BINTRAY_USERNAME}:${BINTRAY_API_KEY} -T gomobile-ipfs-${VERSION}.pom https://api.bintray.com/maven/textile/maven/gomobile-ipfs/io/textile/gomobile-ipfs/${VERSION}/gomobile-ipfs-${VERSION}.pom;publish=1
+            curl -i -X PUT -u ${BINTRAY_USERNAME}:${BINTRAY_API_KEY} -T gomobile-ipfs-${VERSION}.aar https://api.bintray.com/maven/textile/maven/gomobile-ipfs/io/textile/gomobile-ipfs/${VERSION}/gomobile-ipfs-${VERSION}.aar;publish=1
+            curl -i -X POST -u ${BINTRAY_USERNAME}:${BINTRAY_API_KEY} https://api.bintray.com/content/textile/maven/gomobile-ipfs/${VERSION}/publish
+
+workflows:
+  version: 2
+  gomobile-ipfs:
+    jobs:
+      - persist-checkout:
+          filters:
+            tags:
+              only: /.*/
+      - unit-test:
+          requires:
+            - persist-checkout
+          filters:
+            tags:
+              only: /.*/
+      - build-ios-framework:
+          requires:
+            - unit-test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+      - build-android-aar:
+          requires:
+            - unit-test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+      - release:
+          requires:
+            - build-ios-framework
+            - build-android-aar
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish-cocoapod:
+          requires:
+            - release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish-aar:
+          requires:
+            - release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/release/gomobile-ipfs-template.pom
+++ b/release/gomobile-ipfs-template.pom
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.textile</groupId>
+  <artifactId>gomobile-ipfs</artifactId>
+  <version><VERSION></version>
+  <packaging>aar</packaging>
+  <name>gomobile-ipfs</name>
+  <description>Generated core API for Textile</description>
+  <url>https://github.com/textileio/gomobile-ipfs</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>textile</id>
+      <name>Textile</name>
+      <email>contact@textile.io</email>
+    </developer>
+  </developers>
+  <scm>
+    <connection>https://github.com/textileio/gomobile-ipfs.git</connection>
+    <developerConnection>https://github.com/textileio/gomobile-ipfs.git</developerConnection>
+    <url>https://github.com/textileio/gomobile-ipfs</url>
+  </scm>
+</project>

--- a/release/gomobile-ipfs.podspec
+++ b/release/gomobile-ipfs.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |spec|
+  spec.name         = "gomobile-ipfs"
+  spec.version      = "<version>"
+  spec.summary      = "A peer-to-peer hypermedia protocol designed to make the web faster, safer, and more open."
+  spec.description  = <<-DESC
+                      Objective C framework for gomobile-ipfs. You should not usually use this pod directly, but instead use the ipfs pod.
+                    DESC
+  spec.homepage     = "https://github.com/textileio/gomobile-ipfs"
+  spec.license      = "MIT"
+  spec.author       = { "textile.io" => "contact@textile.io" }
+  spec.platform     = :ios, "7.0"
+  spec.source       = spec.source = { :http => 'https://github.com/textileio/gomobile-ipfs/releases/download/v<version>/gomobile-ipfs_v<version>_ios-framework.tar.gz' }
+  spec.vendored_frameworks = 'Mobile.framework'
+  spec.requires_arc = false
+  spec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1', 'OTHER_LDFLAGS[arch=i386]' => '-Wl,-read_only_relocs,suppress' }
+end


### PR DESCRIPTION
Depends on #5 being merged first.

This PR adds a CircleCI config and some release config files that:

- Run tests on every branch commit
- Build the iOS `.framework` and Android `.aar` on each commit to master, save the libraries as artifacts
- Use some special sauce (see `config.yml`'s `build-ios-framework` job) to build an iOS framework that Apple with actually approve for App Store distribution (the current/default `gomobile` creates `.frameworks` that use some illegal API Apple will reject apps for)
- Publish source code + libraries as a Github release on every release tag
- Release the iOS `.framework` and Android `.aar` on Cocoapods and Bintray maven respectively on every release tag

This provides a nice foundation to build iOS, Android and React Native libraries from. Presumably, those libraries will depend on the artifacts published by this repo.

A couple notes/todos:

- You can see the Github releases working at https://github.com/textileio/gomobile-ipfs/releases
- The publishing of the Cocoapod fails because the repo is currently private (the Cocoapod relies on downloading the `.framework` archive from the Github release, but can't since the Github repo is private). It should work fine once the repo is public. 
- The Android lib is currently being published to https://dl.bintray.com/textile/maven/io/textile/gomobile-ipfs but that will change, see next bullet
-  The current `.pom`, `.podspec` and build configuration use "Textile" naming for various things. We will update that once this is merged and lives in a Berty or ifps-shipyard repo and we can use their CI and Maven organizations.