### PR TITLE
ci: restore gradle file after docgen for Android bridge publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,11 @@ jobs:
       - name: Generate Android/iOS Bridge docs
         run:
           sed -i_ 's/implementation.*go_core\.android.*//g'
-          android/bridge/build.gradle;
-          gem install jazzy;
-          rm -rf docs;
-          cd packages && make docgen
+          android/bridge/build.gradle
+          && gem install jazzy
+          && rm -rf docs
+          && cd packages && make docgen
+          && mv android/bridge/build.gradle{_,}
 
       - name: Create semantic-release config file
         run: |

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ solutions and exchange tips.
 
 ## Roadmap
 
-- [x] Basic Java/Swift <-> go-ipfs bindings
-- [x] Packages built and published using CI
-- [ ] Unit tests using Android/iOS testing frameworks (in progress)
-- [ ] InputStream as request body and request response (in progress)
-- [ ] React-Native module (in progress)
-- [ ] `SetStreamHandler(protocolID, handler)` and
+* [x] Basic Java/Swift <-> go-ipfs bindings
+* [x] Packages built and published using CI
+* [ ] Unit tests using Android/iOS testing frameworks (in progress)
+* [ ] InputStream as request body and request response (in progress)
+* [ ] React-Native module (in progress)
+* [ ] `SetStreamHandler(protocolID, handler)` and
 `NewStream(peerID, protocolID)` bindings
-- [ ] Android/iOS lifecycle management
-- [ ] Improve this README
+* [ ] Android/iOS lifecycle management
+* [ ] Improve this README
 
 ## Build
 


### PR DESCRIPTION
# Description

<!-- Describe anything relevant about your PR here. -->
To generate the Android Bridge doc without having to build Android Core, the Core import was removed from the android/bridge/build.grade file while the doc was being generated.

The file in question was not restored afterwards, which was a problem when building and publishing the Android Bridge.

See: https://github.com/ipfs-shipyard/gomobile-ipfs/runs/513349545#step:14:2547

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
