### PR TITLE
ci: fix wrong cwd when restoring gradle file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           android/bridge/build.gradle
           && gem install jazzy
           && rm -rf docs
-          && cd packages && make docgen
+          && (cd packages && make docgen)
           && mv android/bridge/build.gradle{_,}
 
       - name: Create semantic-release config file


### PR DESCRIPTION
# Description

<!-- Describe anything relevant about your PR here. -->

It's painful to fix a CI job triggered by a `on.push.master` event. ^^

This time I just forgot the cwd when restoring the `build.gradle` backup.
See: https://github.com/ipfs-shipyard/gomobile-ipfs/runs/516495286#step:3:101

I hope that this time everything is good.

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
