### PR TITLE
WIP: feat: implement InputStream as request input/output

### DIFF
--- a/android/app/src/main/java/ipfs/gomobile/example/FetchFile.java
+++ b/android/app/src/main/java/ipfs/gomobile/example/FetchFile.java
@@ -45,7 +45,7 @@ final class FetchFile extends AsyncTask<Void, Void, String> {
         try {
             fetchedData = ipfs.newRequest("cat")
                 .withArgument(cid)
-                .send();
+                .sendToBytes();
 
 //            Log.d(TAG, "fetched file data=" + MainActivity.bytesToHex(fetchedData));
             return activity.getString(R.string.titleFetchedImage);

--- a/android/app/src/main/java/ipfs/gomobile/example/FetchRandomXKCD.java
+++ b/android/app/src/main/java/ipfs/gomobile/example/FetchRandomXKCD.java
@@ -52,7 +52,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
                 String address = String.format("%s/latest/info.json", XKCDIPNS);
                 byte[] latestRaw = ipfs.newRequest("cat")
                     .withArgument(address)
-                    .send();
+                    .sendToBytes();
 
                 XKCDLatest = new JSONObject(new String(latestRaw)).getInt("num");
             }
@@ -62,7 +62,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
 
             byte[] infoRaw = ipfs.newRequest("cat")
                 .withArgument(String.format("%s/%s/info.json", XKCDIPNS, formattedIndex))
-                .send();
+                .sendToBytes();
             JSONObject infoJSON = new JSONObject(new String(infoRaw));
 
             String title = infoJSON.getString("title");
@@ -73,7 +73,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
 
             fetchedData = ipfs.newRequest("cat")
                 .withArgument(String.format("%s/%s/image.%s", XKCDIPNS, formattedIndex, imgExt))
-                .send();
+                .sendToBytes();
 
             return String.format(Locale.US, "%d. %s", randomIndex, title);
         } catch (Exception err) {

--- a/android/app/src/main/res/layout/activity_display_image.xml
+++ b/android/app/src/main/res/layout/activity_display_image.xml
@@ -15,6 +15,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:srcCompat="@android:color/background_dark" />
+        tools:srcCompat="@android:color/background_dark"
+        android:contentDescription="XKCD Image" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
@@ -1,0 +1,73 @@
+package ipfs.gomobile.android;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+final class InputStreamFromGo extends InputStream {
+    private final core.ReadCloser readCloser;
+    private boolean closed;
+
+    InputStreamFromGo(@NonNull core.ReadCloser readCloser) {
+        this.readCloser = readCloser;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            throw new IOException("InputStream already closed");
+        }
+
+        closed = true;
+
+        try {
+            readCloser.close();
+        } catch (Exception e) {
+            throw new IOException(e.getMessage());
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] b = new byte[1];
+
+        try {
+            readCloser.read(b);
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().equals("EOF")) {
+                return -1;
+            }
+            throw new IOException(e.getMessage());
+        }
+
+        return b[0];
+    }
+
+    @Override
+    public int read(@NonNull byte[] b, int off, int len)
+        throws IOException, IndexOutOfBoundsException {
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        try {
+            if (b.length == len) {
+                return (int)readCloser.read(b);
+            }
+
+            byte[] tmp = new byte[len];
+            int read;
+
+            read = (int)readCloser.read(tmp);
+            System.arraycopy(tmp, 0, b, off, read);
+
+            return read;
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().equals("EOF")) {
+                return -1;
+            }
+            throw new IOException(e.getMessage());
+        }
+    }
+}

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
@@ -1,0 +1,22 @@
+package ipfs.gomobile.android;
+
+import java.io.InputStream;
+
+final class InputStreamToGo implements core.Reader {
+    private final InputStream inputStream;
+
+    InputStreamToGo(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public long read(byte[] p) throws Exception {
+        long r = inputStream.read(p);
+
+        if (r == -1) {
+            inputStream.close(); // Auto-close inputStream when EOF is reached
+            throw new Exception("EOF");
+        }
+
+        return r;
+    }
+}

--- a/android/bridge/src/main/java/ipfs/gomobile/android/RequestBuilder.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/RequestBuilder.java
@@ -1,6 +1,8 @@
 package ipfs.gomobile.android;
 
 import androidx.annotation.NonNull;
+import android.os.Build;
+import android.os.StatFs;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -9,12 +11,22 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Scanner;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Scanner;
+
 /**
 * RequestBuilder is an IPFS command request builder.
 */
 public class RequestBuilder {
 
-    private core.RequestBuilder requestBuilder;
+    private final core.RequestBuilder requestBuilder;
 
     /**
     * Package-Private class constructor using RequestBuilder passed by IPFS.newRequest method.
@@ -28,15 +40,30 @@ public class RequestBuilder {
 
     // Send methods
     /**
-    * Sends the request to the underlying go-ipfs node.
+    * Sends the request to the underlying go-ipfs node and returns an InputStream.
+    *
+    * @return An InputStream from which to read the response
+    * @throws RequestBuilderException If sending the request failed
+    * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
+    */
+    public InputStream send() throws RequestBuilderException {
+        try {
+            InputStream inputStream = new InputStreamFromGo(requestBuilder.send());
+            return inputStream;
+        } catch (Exception err) {
+            throw new RequestBuilderException("Failed to send request", err);
+        }
+    }
+    /**
+    * Sends the request to the underlying go-ipfs node and returns a byte array.
     *
     * @return A byte array containing the response
     * @throws RequestBuilderException If sending the request failed
     * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
     */
-    public byte[] send() throws RequestBuilderException {
+    public byte[] sendToBytes() throws RequestBuilderException {
         try {
-            return requestBuilder.send();
+            return requestBuilder.sendToBytes();
         } catch (Exception err) {
             throw new RequestBuilderException("Failed to send request", err);
         }
@@ -50,7 +77,7 @@ public class RequestBuilder {
     * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
     */
     public ArrayList<JSONObject> sendToJSONList() throws RequestBuilderException, JSONException {
-        String raw = new String(this.send());
+        String raw = new String(this.sendToBytes());
 
         ArrayList<JSONObject> jsonList = new ArrayList<>();
         Scanner scanner = new Scanner(raw);
@@ -59,6 +86,88 @@ public class RequestBuilder {
         }
 
         return jsonList;
+    }
+
+    /**
+    * Sends the request to the underlying go-ipfs node and returns a file containing
+    * the response.
+    *
+    * @param output The file in which to output the response
+    * @return The file containing the response
+    * @throws RequestBuilderException If sending the request failed
+    * @throws SecurityException TODO
+    * @throws IOException TODO
+    * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
+    */
+    public File sendToFile(@NonNull File output)
+        throws RequestBuilderException, SecurityException, IOException {
+        Objects.requireNonNull(output, "output should not be null");
+
+        if (!output.exists() && !output.createNewFile()) {
+            throw new RequestBuilderException("Can't create file", new IOException("Can't create file"));
+        }
+
+        InputStream input = send();
+        OutputStream outStream = new FileOutputStream(output);
+
+        try {
+            int blockSize;
+
+            try {
+                StatFs statfs = new StatFs(output.getPath());
+                blockSize = (int) statfs.getBlockSizeLong();
+            } catch (IllegalArgumentException e) {
+                blockSize = 4096;
+            }
+
+            sendToStream(outStream, blockSize);
+            outStream.close();
+        } catch (IOException e) {
+            try { outStream.close(); } catch (IOException ignore) { /* nothing */ }
+            throw e;
+        }
+
+        return output;
+    }
+
+    /**
+    * Sends the request to the underlying go-ipfs node and writes to the output stream.
+    *
+    * @param outStream The stream to which to output the response
+    * @param blockSize The block size for the read buffer
+    * @return The same outStream
+    * @throws RequestBuilderException If sending the request failed
+    * @throws SecurityException TODO
+    * @throws IOException TODO
+    * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
+    */
+    public OutputStream sendToStream(@NonNull OutputStream outStream, int blockSize)
+        throws RequestBuilderException, SecurityException, IOException {
+        Objects.requireNonNull(outStream, "outStream should not be null");
+
+        InputStream input = send();
+
+        try {
+            byte[] buffer = new byte[blockSize];
+            int read;
+
+            while ((read = input.read(buffer)) != -1) {
+                outStream.write(buffer, 0, read);
+            }
+
+            outStream.flush();
+            input.close();
+        } catch (IOException e) {
+            try { input.close(); } catch (IOException ignore) { /* nothing */ }
+            throw e;
+        }
+
+        return outStream;
+    }
+
+    public OutputStream sendToStream(@NonNull OutputStream outStream)
+        throws RequestBuilderException, SecurityException, IOException {
+        return sendToStream(outStream, 4096);
     }
 
     // Argument method
@@ -118,11 +227,24 @@ public class RequestBuilder {
         Objects.requireNonNull(option, "option should not be null");
         Objects.requireNonNull(value, "value should not be null");
 
-        requestBuilder.byteOptions(option, value);
+        requestBuilder.bytesOptions(option, value);
         return this;
     }
 
     // Body methods
+    /**
+    * Adds an InputStream body to the request.
+    *
+    * @param body The InputStream from which to read the body
+    * @return This instance of RequestBuilder
+    * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
+    */
+    public RequestBuilder withBody(@NonNull InputStream body) {
+        Objects.requireNonNull(body, "body should not be null");
+
+        requestBuilder.body(new InputStreamToGo(body));
+        return this;
+    }
     /**
     * Adds a string body to the request.
     *
@@ -147,6 +269,21 @@ public class RequestBuilder {
         Objects.requireNonNull(body, "body should not be null");
 
         requestBuilder.bodyBytes(body);
+        return this;
+    }
+    /**
+    * Adds a file as a body to the request.
+    *
+    * @param body The file to add as a body
+    * @return This instance of RequestBuilder
+    * @throws FileNotFoundException If the file is inaccessible
+    * @see <a href="https://docs.ipfs.io/reference/api/http/">IPFS API Doc</a>
+    */
+    public RequestBuilder withBody(@NonNull File body) throws FileNotFoundException {
+        Objects.requireNonNull(body, "body should not be null");
+
+        FileInputStream fis = new FileInputStream(body);
+        requestBuilder.fileBody(body.getName(), new InputStreamToGo(fis));
         return this;
     }
 

--- a/go/bind/core/shell_test.go
+++ b/go/bind/core/shell_test.go
@@ -88,7 +88,7 @@ func TestShell(t *testing.T) {
 						req.Argument(arg)
 					}
 
-					res, err := req.Send()
+					res, err := req.SendToBytes()
 					if err != nil {
 						t.Error(err)
 					}

--- a/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
+++ b/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AB96057288589CB00AC7579 /* InputStreamFromGo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */; };
+		1AB96058288589CB00AC7579 /* InputStreamToGo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB96056288589CB00AC7579 /* InputStreamToGo.swift */; };
 		8AF76E4826EF532E007DF24A /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */; };
 		8AF76E4926EF532E007DF24A /* CoreBluetooth.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8D1B639D24487FC900CE188F /* ConfigIPFSTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1B639C24487FC900CE188F /* ConfigIPFSTest.swift */; };
@@ -51,6 +53,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputStreamFromGo.swift; sourceTree = "<group>"; };
+		1AB96056288589CB00AC7579 /* InputStreamToGo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputStreamToGo.swift; sourceTree = "<group>"; };
 		8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		8D1B639C24487FC900CE188F /* ConfigIPFSTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigIPFSTest.swift; sourceTree = "<group>"; };
 		8D2C38A324470D470005C2DD /* RequestIPFSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestIPFSTests.swift; sourceTree = "<group>"; };
@@ -134,6 +138,8 @@
 		8DE4ECE72402BFE500B70884 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */,
+				1AB96056288589CB00AC7579 /* InputStreamToGo.swift */,
 				8DE4ECF92402C0ED00B70884 /* Config.swift */,
 				8DE4ECFA2402C0ED00B70884 /* Error.swift */,
 				8DE4ECFB2402C0ED00B70884 /* IPFS.swift */,
@@ -265,7 +271,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AB96057288589CB00AC7579 /* InputStreamFromGo.swift in Sources */,
 				8DE4ED032402C0ED00B70884 /* Repo.swift in Sources */,
+				1AB96058288589CB00AC7579 /* InputStreamToGo.swift in Sources */,
 				8DE4ECFF2402C0ED00B70884 /* SockManager.swift in Sources */,
 				8DE4ED022402C0ED00B70884 /* IPFS.swift in Sources */,
 				8DE4ED002402C0ED00B70884 /* Config.swift in Sources */,
@@ -432,7 +440,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../packages/build/ios/intermediates/core/**";
 				INFOPLIST_FILE = GomobileIPFS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -467,7 +475,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../packages/build/ios/intermediates/core/**";
 				INFOPLIST_FILE = GomobileIPFS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -495,7 +503,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9F2792GBSY;
 				INFOPLIST_FILE = GomobileIPFSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -520,7 +528,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9F2792GBSY;
 				INFOPLIST_FILE = GomobileIPFSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
@@ -1,0 +1,112 @@
+//
+//  InputStreamFromGo.swift
+//  GomobileIPFS
+//
+//  Created by Antoine Eddi on 19/01/2020.
+//
+
+import Foundation
+import Core
+
+public class InputStreamFromGoError: IPFSError {
+    private static var code: Int = 6
+    private static var subdomain: String = "InputStreamFromGo"
+
+    required init(_ description: String, _ optCause: NSError? = nil) {
+        super.init(description, optCause, InputStreamFromGoError.subdomain, InputStreamFromGoError.code)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+public class InputStreamFromGo: InputStream {
+    private var _streamStatus: Stream.Status
+    private var _streamError: Error?
+    private weak var _delegate: StreamDelegate?
+    private var readCloser: CoreReadCloser
+
+    init(_ readCloser: CoreReadCloser) {
+        self._streamStatus = .notOpen
+        self._streamError = nil
+        self.readCloser = readCloser
+        super.init(data: Data())
+    }
+
+    override public var hasBytesAvailable: Bool {
+        if self.streamStatus == .atEnd || self.streamStatus == .closed {
+            return false
+        }
+        return true
+    }
+
+    override public var streamStatus: Stream.Status {
+        return _streamStatus
+    }
+
+    override public var streamError: Error? {
+        return _streamError
+    }
+
+    override public var delegate: StreamDelegate? {
+        get {
+            return _delegate
+        }
+        set {
+            _delegate = newValue
+        }
+    }
+
+    override public func open() {
+        if self._streamStatus == .notOpen {
+            self._streamStatus = .open
+        }
+    }
+
+    override public func close() {
+        if self._streamStatus != .closed {
+            self._streamStatus = .closed
+            try? self.readCloser.close()
+        }
+    }
+
+    override public func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+        if self._streamStatus != .open {
+            self._streamError = InputStreamFromGoError("stream not opened (\(self._streamStatus))")
+            return -1
+        }
+
+        self._streamStatus = .reading
+
+        // swiftlint:disable todo
+        // TODO: Use the buffer argument directly without making a copy.
+        // swiftlint:enable todo
+        let tmp: NSData? = NSMutableData(length: len)
+        var read: Int = 0
+
+        do {
+            try self.readCloser.read(tmp as Data?, n: &read)
+        } catch let err {
+            if err.localizedDescription == "EOF" {
+                self._streamStatus = .atEnd
+                return 0
+            }
+
+            self._streamStatus = .error
+            self._streamError = err
+            return -1
+        }
+
+        tmp!.getBytes(buffer, length: read)
+        self._streamStatus = .open
+
+        return read
+    }
+
+    override public func getBuffer(
+            _ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>,
+            length len: UnsafeMutablePointer<Int>) -> Bool {
+        return false
+    }
+}

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
@@ -1,0 +1,31 @@
+//
+//  InputStreamToGo.swift
+//  GomobileIPFS
+//
+//  Created by CI Agent on 20/01/2020.
+//
+
+import Foundation
+import Core
+
+public class InputStreamToGo: NSObject, CoreReaderProtocol {
+    private var inputStream: InputStream
+
+    init(_ inputStream: InputStream) {
+        self.inputStream = inputStream
+        self.inputStream.open()
+    }
+
+    public func read(_ buffer: Data?, n len: UnsafeMutablePointer<Int>?) throws {
+        var read: Int
+
+        let bytes = UnsafeMutablePointer<UInt8>(OpaquePointer((buffer! as NSData).bytes))
+        read = self.inputStream.read(bytes, maxLength: buffer!.count)
+        len?.initialize(to: read)
+
+        if read == 0 && self.inputStream.streamStatus == .atEnd {
+            self.inputStream.close()
+            throw NSError(domain: "", code: 0, userInfo: ["NSLocalizedDescription": "EOF"])
+        }
+    }
+}

--- a/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
@@ -65,7 +65,7 @@ public class RequestBuilder {
         case .string(let string):
             self.requestBuilder.stringOptions(option, value: string)
         case .bytes(let data):
-            self.requestBuilder.byteOptions(option, value: data)
+            self.requestBuilder.bytesOptions(option, value: data)
         }
 
         return self
@@ -97,13 +97,25 @@ public class RequestBuilder {
         return self
     }
 
-    /// Sends the request to the underlying go-ipfs node
+    /// Sends the request to the underlying go-ipfs node and returns an InputStream
+    /// - Throws: `RequestBuilderError`: If sending the request failed
+    /// - Returns: An InputStream from which to read the response
+    /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
+    public func send() throws -> InputStream {
+        do {
+            return try InputStreamFromGo(self.requestBuilder.send())
+        } catch let error as NSError {
+            throw RequestBuilderError("sending request failed", error)
+        }
+    }
+
+    /// Sends the request to the underlying go-ipfs node and returns a byte array
     /// - Throws: `RequestBuilderError`: If sending the request failed
     /// - Returns: A Data object containing the response
     /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
-    public func send() throws -> Data? {
+    public func sendToBytes() throws -> Data? {
         do {
-            return try self.requestBuilder.send()
+            return try self.requestBuilder.sendToBytes()
         } catch let error as NSError {
             throw RequestBuilderError("sending request failed", error)
         }
@@ -114,7 +126,7 @@ public class RequestBuilder {
     /// - Returns: A dict containing the response
     /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
     public func sendToDict() throws -> [String: Any]? {
-        guard let res = try self.requestBuilder.send() else {
+        guard let res = try self.requestBuilder.sendToBytes() else {
             return nil
         }
 

--- a/ios/Bridge/GomobileIPFSTests/RequestIPFSTests.swift
+++ b/ios/Bridge/GomobileIPFSTests/RequestIPFSTests.swift
@@ -7,11 +7,17 @@
 //
 
 import XCTest
+import CryptoKit
 @testable import GomobileIPFS
 
 class RequestIPFSTests: XCTestCase {
 
     private var ipfs: IPFS!
+    // This CID is the IPFS logo in the Wikipedia mirror. It should exist for a long time.
+    private var fileUri: String = "/ipfs/bafkreifxaqwd63x4bhjj33sfm3pmny2codycx27jo77it33hkexzrawyma"
+    private var expectedFileLength: Int = 2940
+    private var expectedFileSha256: String =
+        "SHA256 digest: b7042c3f6efc09d29dee4566dec6e34270f02bebe977fe89ef67512f9882d860"
 
     override func setUp() {
         do {
@@ -27,7 +33,7 @@ class RequestIPFSTests: XCTestCase {
 
         guard let resolveResp = try ipfs.newRequest("resolve")
             .with(argument: "/ipns/\(domain)")
-                .sendToDict() else {
+            .sendToDict() else {
             XCTFail("error while casting dict for \"resolve\"")
             return
         }
@@ -62,14 +68,49 @@ class RequestIPFSTests: XCTestCase {
     }
 
     func testCatFile() throws {
-        let latestRaw = try ipfs.newRequest("cat")
-            .with(argument: "/ipns/xkcd.hacdias.com/latest/info.json")
-            .send()
+        let response = try ipfs.newRequest("cat")
+            .with(argument: fileUri)
+            .sendToBytes()
 
-        do {
-            try JSONSerialization.jsonObject(with: latestRaw!, options: [])
-        } catch _ {
-            XCTFail("error while parsing fetched JSON:  \(String(decoding: latestRaw!	, as: UTF8.self))")
+        XCTAssertEqual(
+            expectedFileLength,
+            response!.count,
+            "response should have the correct length"
+        )
+        XCTAssertEqual(
+            expectedFileSha256,
+            SHA256.hash(data: response!).description,
+            "response should have the correct SHA256"
+        )
+    }
+
+    func testCatFileStream() throws {
+        var count = 0
+        var hasher = SHA256()
+
+        if let stream = try? ipfs.newRequest("cat")
+                .with(argument: fileUri)
+                .send() {
+            var buf: [UInt8] = [UInt8](repeating: 0, count: 1000)
+            stream.open()
+            while case let len = stream.read(&buf, maxLength: buf.count), len > 0 {
+                count += len
+                hasher.update(data: buf[..<len])
+            }
+            stream.close()
+        } else {
+            XCTFail("error calling ipfs.newRequest")
         }
+
+        XCTAssertEqual(
+            expectedFileLength,
+            count,
+            "response should have the correct length"
+        )
+        XCTAssertEqual(
+            expectedFileSha256,
+            hasher.finalize().description,
+            "response should have the correct SHA256"
+        )
     }
 }

--- a/ios/Example/Example/ViewController.swift
+++ b/ios/Example/Example/ViewController.swift
@@ -107,7 +107,7 @@ class ViewController: UIViewController {
                 do {
                     let fetchedData = try ViewController.ipfs!.newRequest("cat")
                         .with(argument: code)
-                        .send()
+                        .sendToBytes()
      
                     title = "IPFS File"
                     image = UIImage(data: fetchedData!)!
@@ -254,7 +254,7 @@ class ViewController: UIViewController {
                 
                 let fetchedData = try ViewController.ipfs!.newRequest("cat")
                     .with(argument: "\(ViewController.XKCDIPNS)/\(formattedIndex)/image.\(imgExt)")
-                    .send()
+                    .sendToBytes()
                 
                 title = "\(randomIndex). \(fetchedInfo["title"] as! String)"
                 image = UIImage(data: fetchedData!)!


### PR DESCRIPTION
# Description

<!-- Describe anything relevant about your PR here. -->

This PR implements:
- Go standard `ReadCloser` to Swift standard `InputStream`
- Go standard `ReadCloser` to Java standard `InputStream`
- Swift and Java standard `InputStream` to Go standard `ReadCloser`

And implement methods for both Android and iOS to make requests through them.

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- Depends on #38 
