### PR TITLE
ci: increase publish timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release_and_publish:
     name: Create release and publish
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout changes
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Increase publish CI job timeout as the build and upload of apps takes more time, but also the `synchronous` cocoapods flag which adds a lot of time.

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
