### PR TITLE
fix: remove armv7 from XCode archs config (support dropped by gomobile)

### DIFF
--- a/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
+++ b/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
+				VALID_ARCHS = "arm64 arm64e";
 				WATCHOS_DEPLOYMENT_TARGET = "";
 			};
 			name = Debug;
@@ -471,6 +472,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
+				VALID_ARCHS = "arm64 arm64e";
 				WATCHOS_DEPLOYMENT_TARGET = "";
 			};
 			name = Release;

--- a/ios/Example/Example.xcodeproj/project.pbxproj
+++ b/ios/Example/Example.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
+				VALID_ARCHS = "arm64 arm64e";
 			};
 			name = Debug;
 		};
@@ -443,6 +444,7 @@
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
+				VALID_ARCHS = "arm64 arm64e";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
# Description

This PR remove arm7 from `Valid archs` config in Bridge and Example XCode projects.
The reason being that support for 32-bit binaries has been dropped for Darwin in go 1.15: https://golang.org/doc/go1.15#darwin

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
