### PR TITLE
fix: race condition in node's closing

### DIFF
--- a/go/bind/core/node.go
+++ b/go/bind/core/node.go
@@ -31,9 +31,11 @@ type Node struct {
 }
 
 func (n *Node) Close() error {
+	n.muListeners.Lock()
 	for _, l := range n.listeners {
 		l.Close()
 	}
+	n.muListeners.Unlock()
 
 	return n.ipfsMobile.Close()
 }


### PR DESCRIPTION
Signed-off-by: phanquy <phanhuynhquy@gmail.com>

### Description
Fix race condition at https://github.com/ipfs-shipyard/gomobile-ipfs/blob/master/go/bind/core/node.go#L34
If we call ServeUnixSocketAPI() or ServeMultiaddr() at same time with Close(). 

### Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
