### PR TITLE
feat: iso berty labs

### DIFF
--- a/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
@@ -153,7 +153,8 @@ public class IPFS {
     }
 
     /**
-    * Starts this IPFS instance.
+    * Starts this IPFS instance. Also serve config Gateway & API located inside
+    * the config (if any)
     *
     * @throws NodeStartException If the node is already started or if its startup fails
     */
@@ -168,8 +169,9 @@ public class IPFS {
             openRepoIfClosed();
             node = Core.newNode(repo, BLEDriver);
             node.serveUnixSocketAPI(absSockPath);
-            // serve config addresses `Addresses.API` & `Addresses.Gateway`
-            node.serveConfig();
+
+            // serve config Addresses API & Gateway
+            node.serve();
         } catch (Exception e) {
             throw new NodeStartException("Node start failed", e);
         }

--- a/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
@@ -171,7 +171,7 @@ public class IPFS {
             node.serveUnixSocketAPI(absSockPath);
 
             // serve config Addresses API & Gateway
-            node.serve();
+            node.serveConfig();
         } catch (Exception e) {
             throw new NodeStartException("Node start failed", e);
         }
@@ -315,18 +315,35 @@ public class IPFS {
         return new RequestBuilder(requestBuilder);
     }
 
-     /**
+    /**
+     * Serves node gateway over the given multiaddr
+     *
+     * @param multiaddr The multiaddr to listen on
+     * @param writable If true: will also support support `POST`, `PUT`, and `DELETE` methods.
+     * @return The MultiAddr the node is serving on
+     * @throws NodeListenException If the node failed to serve
+     * @see <a href="https://docs.ipfs.io/concepts/ipfs-gateway/#gateway-providers">IPFS Doc</a>
+     */
+    synchronized public String serveGatewayMultiaddr(@NonNull String multiaddr, @NonNull Boolean writable) throws NodeListenException {
+        try {
+            return node.serveGatewayMultiaddr(multiaddr, writable);
+        } catch (Exception e) {
+            throw new NodeListenException("failed to listen on gateway", e);
+        }
+    }
+
+    /**
      * Sets the primary and secondary DNS for gomobile (hacky, will be removed in future version)
      *
      * @param primary The primary DNS address in the form {@code <ip4>:<port>}
      * @param secondary The secondary DNS address in the form {@code <ip4>:<port>}
      */
-     public static void setDNSPair(@NonNull String primary, @NonNull String secondary) {
-         Objects.requireNonNull(primary, "primary should not be null");
-         Objects.requireNonNull(secondary, "secondary should not be null");
+    public static void setDNSPair(@NonNull String primary, @NonNull String secondary) {
+        Objects.requireNonNull(primary, "primary should not be null");
+        Objects.requireNonNull(secondary, "secondary should not be null");
 
-         Core.setDNSPair(primary, secondary, false);
-     }
+        Core.setDNSPair(primary, secondary, false);
+    }
 
     /**
     * Internal helper that opens the repo if it is closed.
@@ -346,6 +363,10 @@ public class IPFS {
     // Exceptions
     public static class ExtraOptionException extends Exception {
         ExtraOptionException(String message, Throwable err) { super(message, err); }
+    }
+
+    public static class NodeListenException extends Exception {
+        NodeListenException(String message, Throwable err) { super(message, err); }
     }
 
     public static class ConfigCreationException extends Exception {

--- a/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/IPFS.java
@@ -168,6 +168,8 @@ public class IPFS {
             openRepoIfClosed();
             node = Core.newNode(repo, BLEDriver);
             node.serveUnixSocketAPI(absSockPath);
+            // serve config addresses `Addresses.API` & `Addresses.Gateway`
+            node.serveConfig();
         } catch (Exception e) {
             throw new NodeStartException("Node start failed", e);
         }

--- a/go/bind/core/init.go
+++ b/go/bind/core/init.go
@@ -27,7 +27,7 @@ func initConfig(out io.Writer, nBitsForKeypair int) (*ipfs_config.Config, error)
 	datastore := defaultDatastoreConfig()
 	conf := &ipfs_config.Config{
 		API: ipfs_config.API{
-			HTTPHeaders: map[string][]string{},
+			HTTPHeaders: map[string][]string{"Access-Control-Allow-Origin": {"http://127.0.0.1:4242", "http://127.0.0.1:5001"}},
 		},
 
 		// setup the node's default addresses.

--- a/go/bind/core/node.go
+++ b/go/bind/core/node.go
@@ -96,16 +96,16 @@ func (n *Node) Close() error {
 }
 
 func (n *Node) ServeUnixSocketAPI(sockpath string) (err error) {
-	_, err = n.ServeMultiaddr("/unix/" + sockpath)
+	_, err = n.ServeAPIMultiaddr("/unix/" + sockpath)
 	return
 }
 
 // ServeTCPAPI on the given port and return the current listening maddr
 func (n *Node) ServeTCPAPI(port string) (string, error) {
-	return n.ServeMultiaddr("/ip4/127.0.0.1/tcp/" + port)
+	return n.ServeAPIMultiaddr("/ip4/127.0.0.1/tcp/" + port)
 }
 
-func (n *Node) ServeConfigAPI() error {
+func (n *Node) ServeConfig() error {
 	cfg, err := n.ipfsMobile.Repo.Config()
 	if err != nil {
 		return err
@@ -113,7 +113,15 @@ func (n *Node) ServeConfigAPI() error {
 
 	if len(cfg.Addresses.API) > 0 {
 		for _, maddr := range cfg.Addresses.API {
-			if _, err := n.ServeMultiaddr(maddr); err != nil {
+			if _, err := n.ServeAPIMultiaddr(maddr); err != nil {
+				log.Printf("cannot serve `%s`: %s", maddr, err.Error())
+			}
+		}
+	}
+
+	if len(cfg.Addresses.Gateway) > 0 {
+		for _, maddr := range cfg.Addresses.Gateway {
+			if _, err := n.ServeAPIMultiaddr(maddr); err != nil {
 				log.Printf("cannot serve `%s`: %s", maddr, err.Error())
 			}
 		}
@@ -122,7 +130,16 @@ func (n *Node) ServeConfigAPI() error {
 	return nil
 }
 
-func (n *Node) ServeGateway(smaddr string, writable bool) (string, error) {
+func (n *Node) ServeUnixSocketGateway(sockpath string, writable bool) (err error) {
+	_, err = n.ServeGatewayMultiaddr("/unix/"+sockpath, writable)
+	return
+}
+
+func (n *Node) ServeTCPGateway(port string, writable bool) (string, error) {
+	return n.ServeGatewayMultiaddr("/ip4/127.0.0.1/tcp/"+port, writable)
+}
+
+func (n *Node) ServeGatewayMultiaddr(smaddr string, writable bool) (string, error) {
 	maddr, err := ma.NewMultiaddr(smaddr)
 	if err != nil {
 		return "", err
@@ -143,10 +160,10 @@ func (n *Node) ServeGateway(smaddr string, writable bool) (string, error) {
 		}
 	}(manet.NetListener(ml))
 
-	return "", nil
+	return ml.Multiaddr().String(), nil
 }
 
-func (n *Node) ServeMultiaddr(smaddr string) (string, error) {
+func (n *Node) ServeAPIMultiaddr(smaddr string) (string, error) {
 	maddr, err := ma.NewMultiaddr(smaddr)
 	if err != nil {
 		return "", err

--- a/go/bind/core/node.go
+++ b/go/bind/core/node.go
@@ -122,7 +122,8 @@ func (n *Node) ServeConfig() error {
 
 	if len(cfg.Addresses.Gateway) > 0 {
 		for _, maddr := range cfg.Addresses.Gateway {
-			if _, err := n.ServeGatewayMultiaddr(maddr, true); err != nil {
+			// public gateway should be readonly by default
+			if _, err := n.ServeGatewayMultiaddr(maddr, false); err != nil {
 				return fmt.Errorf("cannot serve `%s`: %s", maddr, err.Error())
 			}
 		}

--- a/go/bind/core/node.go
+++ b/go/bind/core/node.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -108,21 +109,21 @@ func (n *Node) ServeTCPAPI(port string) (string, error) {
 func (n *Node) ServeConfig() error {
 	cfg, err := n.ipfsMobile.Repo.Config()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get config: %s", err.Error())
 	}
 
 	if len(cfg.Addresses.API) > 0 {
 		for _, maddr := range cfg.Addresses.API {
 			if _, err := n.ServeAPIMultiaddr(maddr); err != nil {
-				log.Printf("cannot serve `%s`: %s", maddr, err.Error())
+				return fmt.Errorf("cannot serve `%s`: %s", maddr, err.Error())
 			}
 		}
 	}
 
 	if len(cfg.Addresses.Gateway) > 0 {
 		for _, maddr := range cfg.Addresses.Gateway {
-			if _, err := n.ServeAPIMultiaddr(maddr); err != nil {
-				log.Printf("cannot serve `%s`: %s", maddr, err.Error())
+			if _, err := n.ServeGatewayMultiaddr(maddr, true); err != nil {
+				return fmt.Errorf("cannot serve `%s`: %s", maddr, err.Error())
 			}
 		}
 	}

--- a/go/bind/core/node.go
+++ b/go/bind/core/node.go
@@ -122,6 +122,30 @@ func (n *Node) ServeConfigAPI() error {
 	return nil
 }
 
+func (n *Node) ServeGateway(smaddr string, writable bool) (string, error) {
+	maddr, err := ma.NewMultiaddr(smaddr)
+	if err != nil {
+		return "", err
+	}
+
+	ml, err := manet.Listen(maddr)
+	if err != nil {
+		return "", err
+	}
+
+	n.muListeners.Lock()
+	n.listeners = append(n.listeners, ml)
+	n.muListeners.Unlock()
+
+	go func(l net.Listener) {
+		if err := n.ipfsMobile.ServeGateway(l, writable); err != nil {
+			log.Printf("serve error: %s", err.Error())
+		}
+	}(manet.NetListener(ml))
+
+	return "", nil
+}
+
 func (n *Node) ServeMultiaddr(smaddr string) (string, error) {
 	maddr, err := ma.NewMultiaddr(smaddr)
 	if err != nil {

--- a/go/bind/core/node_test.go
+++ b/go/bind/core/node_test.go
@@ -1,13 +1,18 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
+
+	ipfs_files "github.com/ipfs/go-ipfs-files"
+	ipfs_coreapi "github.com/ipfs/go-ipfs/core/coreapi"
 
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
@@ -90,6 +95,118 @@ func TestNodeServeAPI(t *testing.T) {
 		_, err = client.Get("http://unix/api/v0/id")
 		if err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestNodeServeGateway(t *testing.T) {
+	var testcontent = []byte("hello world\n")
+
+	t.Run("tpc gateway", func(t *testing.T) {
+		path, clean := testingTempDir(t, "tpc_repo")
+		defer clean()
+
+		node, clean := testingNode(t, path)
+		defer clean()
+
+		smaddr, err := node.ServeTCPGateway("0", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		maddr, err := ma.NewMultiaddr(smaddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr, err := manet.ToNetAddr(maddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		api, err := ipfs_coreapi.NewCoreAPI(node.ipfsMobile.IpfsNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		file := ipfs_files.NewBytesFile(testcontent)
+		resolved, err := api.Unixfs().Add(context.Background(), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cid := resolved.Cid()
+
+		url := fmt.Sprintf("http://%s/ipfs/%s", addr.String(), cid.String())
+		client := http.Client{Timeout: 5 * time.Second}
+
+		resp, err := client.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if bytes.Compare(b, testcontent) != 0 {
+			t.Fatalf("content `%s` are different from `%s`", b, testcontent)
+		}
+	})
+
+	t.Run("uds gateway", func(t *testing.T) {
+		path, clean := testingTempDir(t, "uds_repo")
+		defer clean()
+
+		sockdir, clean := testingTempDir(t, "uds_gateway")
+		defer clean()
+
+		node, clean := testingNode(t, path)
+		defer clean()
+
+		sock := filepath.Join(sockdir, "sock")
+		err := node.ServeUnixSocketGateway(sock, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		client := http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", sock)
+				},
+			},
+		}
+
+		api, err := ipfs_coreapi.NewCoreAPI(node.ipfsMobile.IpfsNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		file := ipfs_files.NewBytesFile(testcontent)
+		resolved, err := api.Unixfs().Add(context.Background(), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cid := resolved.Cid()
+		url := fmt.Sprintf("http://unix/ipfs/%s", cid.String())
+		resp, err := client.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if bytes.Compare(b, testcontent) != 0 {
+			t.Fatalf("content `%s` are different from `%s`", b, testcontent)
 		}
 	})
 }

--- a/go/bind/core/shell_test.go
+++ b/go/bind/core/shell_test.go
@@ -75,7 +75,7 @@ func TestShell(t *testing.T) {
 
 	for clientk, clienttc := range casesClient {
 		t.Run(clientk, func(t *testing.T) {
-			maddr, err := node.ServeMultiaddr(clienttc.MAddr)
+			maddr, err := node.ServeAPIMultiaddr(clienttc.MAddr)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/go/go.mod
+++ b/go/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ipfs/go-ipfs v0.11.0
 	github.com/ipfs/go-ipfs-api v0.3.0
 	github.com/ipfs/go-ipfs-config v0.18.0
+	github.com/ipfs/go-ipfs-files v0.0.9
 	github.com/libp2p/go-libp2p v0.17.0
 	github.com/libp2p/go-libp2p-core v0.13.0
 	github.com/libp2p/go-libp2p-record v0.1.3
@@ -84,7 +85,6 @@ require (
 	github.com/ipfs/go-ipfs-ds-help v0.1.1 // indirect
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0 // indirect
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1 // indirect
-	github.com/ipfs/go-ipfs-files v0.0.9 // indirect
 	github.com/ipfs/go-ipfs-keystore v0.0.2 // indirect
 	github.com/ipfs/go-ipfs-pinner v0.2.1 // indirect
 	github.com/ipfs/go-ipfs-posinfo v0.0.1 // indirect

--- a/go/pkg/ipfsmobile/node.go
+++ b/go/pkg/ipfsmobile/node.go
@@ -78,6 +78,18 @@ func (im *IpfsMobile) ServeCoreHTTP(l net.Listener, opts ...ipfs_corehttp.ServeO
 	return ipfs_corehttp.Serve(im.IpfsNode, l, opts...)
 }
 
+func (im *IpfsMobile) ServeGateway(l net.Listener, writable bool, opts ...ipfs_corehttp.ServeOption) error {
+	opts = append(opts,
+		ipfs_corehttp.HostnameOption(),
+		ipfs_corehttp.GatewayOption(writable, "/ipfs", "/ipns"),
+		ipfs_corehttp.VersionOption(),
+		ipfs_corehttp.CheckVersionOption(),
+		ipfs_corehttp.CommandsROOption(im.commandCtx),
+	)
+
+	return ipfs_corehttp.Serve(im.IpfsNode, l, opts...)
+}
+
 func NewNode(ctx context.Context, cfg *IpfsConfig) (*IpfsMobile, error) {
 	if err := cfg.fillDefault(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)

--- a/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
@@ -105,6 +105,9 @@ public class IPFS {
         let maddr: String = try self.node!.serve(onTCPPort: "0")
         self.shell = CoreNewShell(maddr)
         #endif
+
+        // serve config api & gateway
+        try self.node!.serveConfig()
     }
 
     /// Stops this IPFS instance

--- a/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
@@ -219,12 +219,12 @@ public class IPFS {
     /// - Parameter onMultiaddr: The multiaddr to serve on
     /// - Parameter writable: If true: will also support support `POST`, `PUT`, and `DELETE` methods.
     /// - Throws: `NodeError`: If the node failed to serve
-    public func serve(onTCPPort: String) throws -> String {
+    public func serveAPI(onTCPPort: String) throws -> String {
         guard let node = self.node else {
             throw IPFSError("unable to serve the api, is the node started?")
         }
 
-        return try node.serve(onTCPPort: onTCPPort)
+        return try node.serveAPI(onTCPPort: onTCPPort)
     }
 
 

--- a/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
@@ -106,8 +106,8 @@ public class IPFS {
         self.shell = CoreNewShell(maddr)
         #endif
 
-        // serve config api & gateway
-        try self.node!.serveConfig()
+        // serve config api & gateway (if any)
+        try self.node!.serve()
     }
 
     /// Stops this IPFS instance

--- a/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
@@ -207,12 +207,24 @@ public class IPFS {
     /// - Parameter onMultiaddr: The multiaddr to serve on
     /// - Parameter writable: If true: will also support support `POST`, `PUT`, and `DELETE` methods.
     /// - Throws: `NodeError`: If the node failed to serve
-    public func serveGateway(onMultiaddr: String, _ writable: Bool = false) throws -> String{
+    public func serveGateway(onMultiaddr: String, _ writable: Bool = false) throws -> String {
         guard let node = self.node else {
             throw IPFSError("unable to serve the gateway, is the node started?")
         }
 
         return try node.serveGateway(onMultiaddr: onMultiaddr, writable: writable)
+    }
+
+    /// Serves node opi over the given TCPPort
+    /// - Parameter onMultiaddr: The multiaddr to serve on
+    /// - Parameter writable: If true: will also support support `POST`, `PUT`, and `DELETE` methods.
+    /// - Throws: `NodeError`: If the node failed to serve
+    public func serve(onTCPPort: String) throws -> String {
+        guard let node = self.node else {
+            throw IPFSError("unable to serve the api, is the node started?")
+        }
+
+        return try node.serve(onTCPPort: onTCPPort)
     }
 
 

--- a/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/IPFS.swift
@@ -94,7 +94,7 @@ public class IPFS {
 
         // Create a shell over UDS on physical device
         #if !targetEnvironment(simulator)
-        try self.node!.serve(onUDS: self.absSockPath)
+        try self.node!.serveAPI(onUDS: self.absSockPath)
         self.shell = CoreNewUDSShell(self.absSockPath)
         /*
         ** On iOS simulator, temporary directory's absolute path exceeds
@@ -102,7 +102,7 @@ public class IPFS {
         ** only used for debug, we can safely fallback on shell over TCP
         */
         #else
-        let maddr: String = try self.node!.serve(onTCPPort: "0")
+        let maddr: String = try self.node!.serveAPI(onTCPPort: "0")
         self.shell = CoreNewShell(maddr)
         #endif
 
@@ -202,6 +202,19 @@ public class IPFS {
 
         return RequestBuilder(requestBuilder)
     }
+
+    /// Serves node Gateway over the given Multiaddr
+    /// - Parameter onMultiaddr: The multiaddr to serve on
+    /// - Parameter writable: If true: will also support support `POST`, `PUT`, and `DELETE` methods.
+    /// - Throws: `NodeError`: If the node failed to serve
+    public func serveGateway(onMultiaddr: String, _ writable: Bool = false) throws -> String{
+        guard let node = self.node else {
+            throw IPFSError("unable to serve the gateway, is the node started?")
+        }
+
+        return try node.serveGateway(onMultiaddr: onMultiaddr, writable: writable)
+    }
+
 
     /// Sets the primary and secondary DNS for gomobile (hacky, will be removed in future version)
     /// - Parameters:

--- a/ios/Bridge/GomobileIPFS/Sources/Node.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/Node.swift
@@ -54,7 +54,7 @@ public class Node {
     /// Serves node API over UDS
     /// - Parameter onUDS: The UDS path to serve on
     /// - Throws: `NodeError`: If the node failed to serve
-    public func serve(onUDS: String) throws {
+    public func serveAPI(onUDS: String) throws {
         do {
             try self.node.serveUnixSocketAPI(onUDS)
         } catch let error as NSError {
@@ -66,7 +66,7 @@ public class Node {
     /// - Parameter onTCPPort: The TCP port to serve on
     /// - Throws: `NodeError`: If the node failed to serve
     /// - Returns: The TCP/IP MultiAddr the node is serving on
-    public func serve(onTCPPort: String) throws -> String {
+    public func serveAPI(onTCPPort: String) throws -> String {
         var err: NSError?
 
         let maddr = self.node.serveTCPAPI(onTCPPort, error: &err)
@@ -75,6 +75,21 @@ public class Node {
             throw NodeError("unable to serve api on TCP", err)
         }
 
+        return maddr
+    }
+
+    /// Serves node Gateway over the given Multiaddr
+    /// - Parameter onMultiaddr: The multiaddr to serve on
+    /// - Parameter writable: If true: will also support support `POST`, `PUT`, and `DELETE` methods.
+    /// - Throws: `NodeError`: If the node failed to serve
+    public func serveGateway(onMultiaddr: String, writable: Bool = false) throws -> String{
+        var err: NSError?
+
+        let maddr = self.node.serveGatewayMultiaddr(onMultiaddr, writable: writable, error: &err)
+        if err != nil {
+            throw NodeError("unable to serve gateway on \(onMultiaddr)", err)
+        }
+        
         return maddr
     }
 

--- a/ios/Bridge/GomobileIPFS/Sources/Node.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/Node.swift
@@ -77,4 +77,16 @@ public class Node {
 
         return maddr
     }
+
+    /// Serves any multiaddr (api & gateway) inside `Addresses.Api` and
+    /// `Addresses.Gateway` in the config (if any)
+    /// - Throws: `NodeError`: If the node failed to serve
+    /// - Returns: The TCP/IP MultiAddr the node is serving on
+    public func serve() throws {
+        do {
+            try self.node.serveConfig()
+        } catch let error as NSError {
+            throw NodeError("unable to serve config api", error)
+        }
+    }
 }

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -41,7 +41,7 @@ GO_MOD_FILES = $(GO_DIR)/go.mod $(GO_DIR)/go.sum
 
 CORE_PACKAGE = github.com/ipfs-shipyard/gomobile-ipfs/go/bind/core
 EXT_PACKAGE ?=
-GOMOBILE = go run golang.org/x/mobile/cmd/gomobile
+GOMOBILE ?= go run golang.org/x/mobile/cmd/gomobile
 GOMOBILE_OPT ?=
 GOMOBILE_TARGET ?=
 


### PR DESCRIPTION
this contains the changes required to make gomobile-ipfs work with berty-labs
some are hacky because node configuration seems broken

- add endpoints to serve the api and gateway
- allow localhost with cors for easy access to the api and gateway (required for the webui  for example)

once this is merged, labs is bumped and the release is validated by apple, the upstream ipfs-shipyard/gomobile-ipfs will be used in an app published on the appstore which is a milestone for me 

next step IMO is to fix the cocoapod index to enable react-native "auto-linking" and merge/publish the react-native-gomobile-ipfs package

...then.. android