### PR TITLE
Fixed javadoc generation for java > 1.8

### DIFF
--- a/packages/Manifest.yml
+++ b/packages/Manifest.yml
@@ -40,6 +40,7 @@ global:
     target_sdk_version: *compile_sdk_version
     repo: gomobile-ipfs-android
     packaging: aar
+    bintray_url: https://repo1.maven.org/maven2/
 
     scm:
       connection: scm:git:git://github.com/ipfs-shipyard/gomobile-ipfs.git

--- a/packages/utils/maven_format/maven_format_core.py
+++ b/packages/utils/maven_format/maven_format_core.py
@@ -108,8 +108,14 @@ try:
                          )):
                 exit(1)
         else:
-            # TODO: add Android javadoc generation using Java version > 1.8
-            raise Exception("Can't generate javadoc using Java version > 1.8")
+            if os.system("javadoc -Xdoclint:none -quiet -classpath '%s' "
+                         "-sourcepath '%s' go core -d %s" %
+                         (
+                            target_sdk_path,
+                            temp_dir,
+                            os.path.join(temp_dir, "javadoc")
+                         )):
+                exit(1)
 
         # Create a jar containing the javadoc
         if os.system("cd %s && jar -cf ../%s ." %


### PR DESCRIPTION
# Description

Small addition to enable JavaDoc generation on newer versions of java when building Android core.

## Related

<!-- List related issues and pull requests here using either the keyword
"fixes" or "addresses", for example:
	- fixes #42
	- fixes #24
	- addresses #1337
-->

- None
