### PR TITLE
fix: In testCatFile, fetch a reliable sample file

### DIFF
--- a/android/bridge/src/androidTest/java/ipfs/gomobile/android/requestIPFSTests.java
+++ b/android/bridge/src/androidTest/java/ipfs/gomobile/android/requestIPFSTests.java
@@ -66,13 +66,13 @@ public class requestIPFSTests {
     @Test
     public void testCatFile() throws Exception {
         byte[] latestRaw = ipfs.newRequest("cat")
-                .withArgument("/ipns/xkcd.hacdias.com/latest/info.json")
+                .withArgument("/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu")
                 .send();
 
-        try {
-            new JSONObject(new String(latestRaw));
-        } catch (JSONException e) {
-            fail("error while parsing fetched JSON: " + new String(latestRaw));
-        }
+        assertEquals(
+            "response should have the correct length",
+            12435,
+            latestRaw.length
+        );
     }
 }


### PR DESCRIPTION
Change to a CID of a sample image from the IPFS web site which is likely to be fetched.

# Description

The request to fetch the IPNS file times out. Change to a CID of a sample image from the IPFS web site which is likely to be fetched. With this change, all the tests pass.
