### PR TITLE
fix: In Manifest.yml, give the bintray_url for maven

### DIFF
--- a/packages/Manifest.yml
+++ b/packages/Manifest.yml
@@ -40,6 +40,7 @@ global:
     target_sdk_version: *compile_sdk_version
     repo: gomobile-ipfs-android
     packaging: aar
+    bintray_url: https://repo1.maven.org/maven2/
 
     scm:
       connection: scm:git:git://github.com/ipfs-shipyard/gomobile-ipfs.git


### PR DESCRIPTION
Fix `make test_bridge.android` build error.

# Description

`make test_bridge.android` gives the build error "A problem occurred configuring project ':bridge'. You must specify a URL for a Maven repository." This pull request fixes the error by adding `bintray_url` .

