### PR TITLE
Feat/implement inputstream

### DIFF
--- a/android/app/src/main/java/ipfs/gomobile/example/FetchRandomXKCD.java
+++ b/android/app/src/main/java/ipfs/gomobile/example/FetchRandomXKCD.java
@@ -14,10 +14,9 @@ import ipfs.gomobile.android.IPFS;
 final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
     private static final String TAG = "FetchRandomXKCD";
 
-    private static final String XKCDIPNS = "/ipns/xkcd.hacdias.com";
-
     private static Random random = new Random();
 
+    private static final String XKCDIPNS = "/ipns/xkcd.hacdias.com";
     private static int XKCDLatest = -1;
 
     private final WeakReference<MainActivity> activityRef;
@@ -51,7 +50,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
                 String address = String.format("%s/latest/info.json", XKCDIPNS);
                 byte[] latestRaw = ipfs.newRequest("cat")
                     .withArgument(address)
-                    .send();
+                    .sendToBytes();
 
                 XKCDLatest = new JSONObject(new String(latestRaw)).getInt("num");
             }
@@ -61,7 +60,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
 
             byte[] infoRaw = ipfs.newRequest("cat")
                 .withArgument(String.format("%s/%s/info.json", XKCDIPNS, formattedIndex))
-                .send();
+                .sendToBytes();
             JSONObject infoJSON = new JSONObject(new String(infoRaw));
 
             String title = infoJSON.getString("title");
@@ -72,7 +71,7 @@ final class FetchRandomXKCD extends AsyncTask<Void, Void, String> {
 
             fetchedData = ipfs.newRequest("cat")
                 .withArgument(String.format("%s/%s/image.%s", XKCDIPNS, formattedIndex, imgExt))
-                .send();
+                .sendToBytes();
 
             return String.format("%d. %s", randomIndex, title);
         } catch (Exception err) {

--- a/android/app/src/main/res/layout/activity_display_image.xml
+++ b/android/app/src/main/res/layout/activity_display_image.xml
@@ -15,6 +15,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:srcCompat="@android:color/background_dark" />
+        tools:srcCompat="@android:color/background_dark"
+        android:contentDescription="XKCD Image" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/bridge/src/androidTest/java/ipfs/gomobile/android/requestIPFSTests.java
+++ b/android/bridge/src/androidTest/java/ipfs/gomobile/android/requestIPFSTests.java
@@ -67,7 +67,7 @@ public class requestIPFSTests {
     public void testCatFile() throws Exception {
         byte[] latestRaw = ipfs.newRequest("cat")
                 .withArgument("/ipns/xkcd.hacdias.com/latest/info.json")
-                .send();
+                .sendToBytes();
 
         try {
             new JSONObject(new String(latestRaw));

--- a/android/bridge/src/main/AndroidManifest.xml
+++ b/android/bridge/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="ipfs.gomobile.android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application android:networkSecurityConfig="@xml/network_security_config" tools:ignore="UnusedAttribute" />
 </manifest>

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
@@ -1,0 +1,75 @@
+package ipfs.gomobile.android;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import ipfs.ReadCloser;
+
+final class InputStreamFromGo extends InputStream {
+    private final ReadCloser readCloser;
+    private boolean closed;
+
+    InputStreamFromGo(ReadCloser readCloser) {
+        this.readCloser = readCloser;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            throw new IOException("InputStream already closed");
+        }
+
+        closed = true;
+
+        try {
+            readCloser.close();
+        } catch (Exception e) {
+            throw new IOException(e.getMessage());
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] b = new byte[1];
+
+        try {
+            readCloser.read(b);
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().equals("EOF")) {
+                return -1;
+            }
+            throw new IOException(e.getMessage());
+        }
+
+        return b[0];
+    }
+
+    @Override
+    public int read(@NonNull byte[] b, int off, int len)
+        throws IOException, IndexOutOfBoundsException {
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        try {
+            if (b.length == len) {
+                return (int)readCloser.read(b);
+            }
+
+            byte[] tmp = new byte[len];
+            int read;
+
+            read = (int)readCloser.read(tmp);
+            System.arraycopy(tmp, 0, b, off, read);
+
+            return read;
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().equals("EOF")) {
+                return -1;
+            }
+            throw new IOException(e.getMessage());
+        }
+    }
+}

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamFromGo.java
@@ -5,13 +5,11 @@ import androidx.annotation.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 
-import ipfs.ReadCloser;
-
 final class InputStreamFromGo extends InputStream {
-    private final ReadCloser readCloser;
+    private final core.ReadCloser readCloser;
     private boolean closed;
 
-    InputStreamFromGo(ReadCloser readCloser) {
+    InputStreamFromGo(@NonNull core.ReadCloser readCloser) {
         this.readCloser = readCloser;
     }
 

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
@@ -1,0 +1,24 @@
+package ipfs.gomobile.android;
+
+import java.io.InputStream;
+
+import ipfs.Reader;
+
+final class InputStreamToGo implements Reader {
+    private final InputStream inputStream;
+
+    InputStreamToGo(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public long read(byte[] p) throws Exception {
+        long r = inputStream.read(p);
+
+        if (r == -1) {
+            inputStream.close(); // Auto-close inputStream when EOF is reached
+            throw new Exception("EOF");
+        }
+
+        return r;
+    }
+}

--- a/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/InputStreamToGo.java
@@ -2,9 +2,7 @@ package ipfs.gomobile.android;
 
 import java.io.InputStream;
 
-import ipfs.Reader;
-
-final class InputStreamToGo implements Reader {
+final class InputStreamToGo implements core.Reader {
     private final InputStream inputStream;
 
     InputStreamToGo(InputStream inputStream) {

--- a/android/bridge/src/main/java/ipfs/gomobile/android/RequestBuilder.java
+++ b/android/bridge/src/main/java/ipfs/gomobile/android/RequestBuilder.java
@@ -100,10 +100,10 @@ public class RequestBuilder {
     */
     public File sendToFile(@NonNull File output)
         throws RequestBuilderException, SecurityException, IOException {
-        Objects.requireNonNull(argument, "output should not be null");
+        Objects.requireNonNull(output, "output should not be null");
 
         if (!output.exists() && !output.createNewFile()) {
-            throw new RequestBuilderException("Can't create file");
+            throw new RequestBuilderException("Can't create file", new IOException("Can't create file"));
         }
 
         InputStream input = send();

--- a/go/bind/core/shell.go
+++ b/go/bind/core/shell.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"strings"
 
 	ipfs_api "github.com/ipfs/go-ipfs-api"
+	files "github.com/ipfs/go-ipfs-files"
 )
 
 type Shell struct {
@@ -30,7 +32,16 @@ type RequestBuilder struct {
 	rb *ipfs_api.RequestBuilder
 }
 
-func (req *RequestBuilder) Send() ([]byte, error) {
+func (req *RequestBuilder) Send() (*ReadCloser, error) {
+	res, err := req.rb.Send(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReadCloser{res.Output}, res.Error
+}
+
+func (req *RequestBuilder) SendToBytes() ([]byte, error) {
 	res, err := req.rb.Send(context.Background())
 	if err != nil {
 		return nil, err
@@ -52,12 +63,16 @@ func (req *RequestBuilder) BoolOptions(key string, value bool) {
 	req.rb.Option(key, value)
 }
 
-func (req *RequestBuilder) ByteOptions(key string, value []byte) {
+func (req *RequestBuilder) BytesOptions(key string, value []byte) {
 	req.rb.Option(key, value)
 }
 
 func (req *RequestBuilder) StringOptions(key string, value string) {
 	req.rb.Option(key, value)
+}
+
+func (req *RequestBuilder) Body(body Reader) {
+	req.rb.Body(body)
 }
 
 func (req *RequestBuilder) BodyString(body string) {
@@ -72,8 +87,30 @@ func (req *RequestBuilder) BodyBytes(body []byte) {
 	req.rb.BodyBytes(dest)
 }
 
+func (req *RequestBuilder) FileBody(name string, body Reader) {
+	fr := files.NewReaderFile(body)
+	slf := files.NewSliceDirectory([]files.DirEntry{files.FileEntry(name, fr)})
+	req.rb.Body(files.NewMultiFileReader(slf, false))
+}
+
 func (req *RequestBuilder) Header(name, value string) {
 	req.rb.Header(name, value)
+}
+
+type Reader interface {
+	io.Reader
+}
+
+type ReadCloser struct {
+	readCloser io.ReadCloser
+}
+
+func (rc *ReadCloser) Close() error {
+	return rc.readCloser.Close()
+}
+
+func (rc *ReadCloser) Read(p []byte) (n int, err error) {
+	return rc.readCloser.Read(p)
 }
 
 // Helpers

--- a/go/bind/core/shell_test.go
+++ b/go/bind/core/shell_test.go
@@ -88,7 +88,7 @@ func TestShell(t *testing.T) {
 						req.Argument(arg)
 					}
 
-					res, err := req.Send()
+					res, err := req.SendToBytes()
 					if err != nil {
 						t.Error(err)
 					}

--- a/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
+++ b/ios/Bridge/GomobileIPFS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AB96057288589CB00AC7579 /* InputStreamFromGo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */; };
+		1AB96058288589CB00AC7579 /* InputStreamToGo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB96056288589CB00AC7579 /* InputStreamToGo.swift */; };
 		8AF76E4826EF532E007DF24A /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */; };
 		8AF76E4926EF532E007DF24A /* CoreBluetooth.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8D1B639D24487FC900CE188F /* ConfigIPFSTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1B639C24487FC900CE188F /* ConfigIPFSTest.swift */; };
@@ -51,6 +53,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputStreamFromGo.swift; sourceTree = "<group>"; };
+		1AB96056288589CB00AC7579 /* InputStreamToGo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputStreamToGo.swift; sourceTree = "<group>"; };
 		8AF76E4626EA36F9007DF24A /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		8D1B639C24487FC900CE188F /* ConfigIPFSTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigIPFSTest.swift; sourceTree = "<group>"; };
 		8D2C38A324470D470005C2DD /* RequestIPFSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestIPFSTests.swift; sourceTree = "<group>"; };
@@ -134,6 +138,8 @@
 		8DE4ECE72402BFE500B70884 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				1AB96055288589CB00AC7579 /* InputStreamFromGo.swift */,
+				1AB96056288589CB00AC7579 /* InputStreamToGo.swift */,
 				8DE4ECF92402C0ED00B70884 /* Config.swift */,
 				8DE4ECFA2402C0ED00B70884 /* Error.swift */,
 				8DE4ECFB2402C0ED00B70884 /* IPFS.swift */,
@@ -265,7 +271,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AB96057288589CB00AC7579 /* InputStreamFromGo.swift in Sources */,
 				8DE4ED032402C0ED00B70884 /* Repo.swift in Sources */,
+				1AB96058288589CB00AC7579 /* InputStreamToGo.swift in Sources */,
 				8DE4ECFF2402C0ED00B70884 /* SockManager.swift in Sources */,
 				8DE4ED022402C0ED00B70884 /* IPFS.swift in Sources */,
 				8DE4ED002402C0ED00B70884 /* Config.swift in Sources */,

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
@@ -1,0 +1,107 @@
+//
+//  InputStreamFromGo.swift
+//  GomobileIPFS
+//
+//  Created by Antoine Eddi on 19/01/2020.
+//
+
+import Foundation
+import Ipfs
+
+public class InputStreamFromGoError: IPFSError  {
+    private static var code: Int = 6
+    private static var subdomain: String = "InputStreamFromGo"
+
+    required init(_ description: String, _ optCause: NSError? = nil) {
+        super.init(description, optCause, InputStreamFromGoError.subdomain, InputStreamFromGoError.code)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+public class InputStreamFromGo: InputStream {
+    private var _streamStatus: Stream.Status
+    private var _streamError: Error?
+    private var _delegate: StreamDelegate?
+    private var readCloser: IpfsReadCloser
+
+    init(_ readCloser: IpfsReadCloser) {
+        self._streamStatus = .notOpen
+        self._streamError = nil
+        self.readCloser = readCloser
+        super.init(data: Data())
+    }
+
+    override public var hasBytesAvailable: Bool {
+        if self.streamStatus == .atEnd || self.streamStatus == .closed {
+            return false
+        }
+        return true
+    }
+
+    override public var streamStatus: Stream.Status {
+        return _streamStatus
+    }
+
+    override public var streamError: Error? {
+        return _streamError
+    }
+
+    override public var delegate: StreamDelegate? {
+        get {
+            return _delegate
+        }
+        set {
+            _delegate = newValue
+        }
+    }
+
+    override public func open() {
+        if self._streamStatus == .notOpen {
+            self._streamStatus = .open
+        }
+    }
+
+    override public func close() {
+        if self._streamStatus != .closed {
+            self._streamStatus = .closed
+            try? self.readCloser.close()
+        }
+    }
+
+    override public func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+        if self._streamStatus != .open {
+            self._streamError = InputStreamFromGoError("stream not opened (\(self._streamStatus))")
+            return -1
+        }
+
+        self._streamStatus = .reading
+
+        let tmp = Data(capacity: len)
+        var read: Int = 0
+
+        do {
+            try self.readCloser.read(tmp, n: &read)
+        } catch let err {
+            if err.localizedDescription == "EOF" {
+                self._streamStatus = .atEnd
+                return 0
+            }
+
+            self._streamStatus = .error
+            self._streamError = err
+            return -1
+        }
+
+        tmp.copyBytes(to: buffer, count: read)
+        self._streamStatus = .open
+
+        return read
+    }
+
+    override public func getBuffer(_ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>, length len: UnsafeMutablePointer<Int>) -> Bool {
+        return false
+    }
+}

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamFromGo.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Ipfs
+import Core
 
 public class InputStreamFromGoError: IPFSError  {
     private static var code: Int = 6
@@ -25,9 +25,9 @@ public class InputStreamFromGo: InputStream {
     private var _streamStatus: Stream.Status
     private var _streamError: Error?
     private var _delegate: StreamDelegate?
-    private var readCloser: IpfsReadCloser
+    private var readCloser: CoreReadCloser
 
-    init(_ readCloser: IpfsReadCloser) {
+    init(_ readCloser: CoreReadCloser) {
         self._streamStatus = .notOpen
         self._streamError = nil
         self.readCloser = readCloser

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
@@ -1,0 +1,31 @@
+//
+//  InputStreamToGo.swift
+//  GomobileIPFS
+//
+//  Created by CI Agent on 20/01/2020.
+//
+
+import Foundation
+import Ipfs
+
+public class InputStreamToGo: NSObject, IpfsReaderProtocol {
+    private var inputStream: InputStream
+
+    init(_ inputStream: InputStream) {
+        self.inputStream = inputStream
+        self.inputStream.open()
+    }
+
+    public func read(_ p0: Data?, n: UnsafeMutablePointer<Int>?) throws {
+        var read: Int
+
+        var bytes = UnsafeMutablePointer<UInt8>((p0 as! NSData).bytes)
+        read = self.inputStream.read(p0, maxLength: p0?.count)
+        n?.initialize(to: read)
+
+        if read == 0 && self.inputStream.streamStatus == .atEnd {
+            self.inputStream.close()
+            throw NSError(domain: "", code: 0, userInfo: ["NSLocalizedDescription": "EOF"])
+        }
+    }
+}

--- a/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/InputStreamToGo.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import Ipfs
+import Core
 
-public class InputStreamToGo: NSObject, IpfsReaderProtocol {
+public class InputStreamToGo: NSObject, CoreReaderProtocol {
     private var inputStream: InputStream
 
     init(_ inputStream: InputStream) {
@@ -19,8 +19,8 @@ public class InputStreamToGo: NSObject, IpfsReaderProtocol {
     public func read(_ p0: Data?, n: UnsafeMutablePointer<Int>?) throws {
         var read: Int
 
-        var bytes = UnsafeMutablePointer<UInt8>((p0 as! NSData).bytes)
-        read = self.inputStream.read(p0, maxLength: p0?.count)
+        let bytes = UnsafeMutablePointer<UInt8>(OpaquePointer((p0! as NSData).bytes))
+        read = self.inputStream.read(bytes, maxLength: p0!.count)
         n?.initialize(to: read)
 
         if read == 0 && self.inputStream.streamStatus == .atEnd {

--- a/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
@@ -65,7 +65,7 @@ public class RequestBuilder {
         case .string(let string):
             self.requestBuilder.stringOptions(option, value: string)
         case .bytes(let data):
-            self.requestBuilder.byteOptions(option, value: data)
+            self.requestBuilder.bytesOptions(option, value: data)
         }
 
         return self
@@ -99,11 +99,23 @@ public class RequestBuilder {
 
     /// Sends the request to the underlying go-ipfs node
     /// - Throws: `RequestBuilderError`: If sending the request failed
+    /// - Returns: An InputStream from which to read the response
+    /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
+    public func send() throws -> InputStream {
+        do {
+            return try InputStreamFromGo(self.requestBuilder.send())
+        } catch let error as NSError {
+            throw RequestBuilderError("sending request failed", error)
+        }
+    }
+
+    /// Sends the request to the underlying go-ipfs node
+    /// - Throws: `RequestBuilderError`: If sending the request failed
     /// - Returns: A Data object containing the response
     /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
-    public func send() throws -> Data {
+    public func sendToByes() throws -> Data {
         do {
-            return try self.requestBuilder.send()
+            return try self.requestBuilder.sendToBytes()
         } catch let error as NSError {
             throw RequestBuilderError("sending request failed", error)
         }

--- a/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
+++ b/ios/Bridge/GomobileIPFS/Sources/RequestBuilder.swift
@@ -113,7 +113,7 @@ public class RequestBuilder {
     /// - Throws: `RequestBuilderError`: If sending the request failed
     /// - Returns: A Data object containing the response
     /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
-    public func sendToByes() throws -> Data {
+    public func sendToBytes() throws -> Data {
         do {
             return try self.requestBuilder.sendToBytes()
         } catch let error as NSError {
@@ -126,7 +126,7 @@ public class RequestBuilder {
     /// - Returns: A dict containing the response
     /// - seealso: [IPFS API Doc](https://docs.ipfs.io/reference/api/http/)
     public func sendToDict() throws -> [String: Any] {
-        let res = try self.requestBuilder.send()
+        let res = try self.requestBuilder.sendToBytes()
 
         do {
             let json = try JSONSerialization.jsonObject(with: res, options: [])

--- a/ios/Bridge/GomobileIPFSTests/RequestIPFSTests.swift
+++ b/ios/Bridge/GomobileIPFSTests/RequestIPFSTests.swift
@@ -58,7 +58,7 @@ class RequestIPFSTests: XCTestCase {
     func testCatFile() throws {
         let latestRaw = try ipfs.newRequest("cat")
             .with(argument: "/ipns/xkcd.hacdias.com/latest/info.json")
-            .send()
+            .sendToBytes()
 
         do {
             try JSONSerialization.jsonObject(with: latestRaw, options: [])


### PR DESCRIPTION
# Description

<!-- Describe anything relevant about your PR here. -->

This PR implements:
- Go standard `ReadCloser` to Swift standard `InputStream`
- Go standard `ReadCloser` to Java standard `InputStream`
- Swift and Java standard `InputStream` to Go standard `ReadCloser`

And implement methods for both Android and iOS to make requests through them.

## Related

- This replaces and extends the original #39

- Depends on #38 
