### PR TITLE
chore: Bump gomobile version to v0.0.8

### DIFF
--- a/packages/go.mod
+++ b/packages/go.mod
@@ -243,5 +243,5 @@ require (
 replace (
 	github.com/ipfs-shipyard/gomobile-ipfs/go => ../go
 	github.com/lucas-clemente/quic-go => github.com/lucas-clemente/quic-go v0.25.0
-	golang.org/x/mobile => github.com/berty/mobile v0.0.7 // temporary, see https://github.com/golang/mobile/pull/58 and https://github.com/golang/mobile/pull/82
+	golang.org/x/mobile => github.com/berty/mobile v0.0.8 // temporary, see https://github.com/golang/mobile/pull/58 and https://github.com/golang/mobile/pull/82
 )

--- a/packages/go.sum
+++ b/packages/go.sum
@@ -88,8 +88,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/berty/mobile v0.0.7 h1:c4UaGa43dCzTCgq2wkWwglbgLe8kLaS95mit7h94SV4=
-github.com/berty/mobile v0.0.7/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
+github.com/berty/mobile v0.0.8 h1:DoIuvRWaHPvrrVtLxg1ZFu9n1cTVQwkK1PkI6XbzC5M=
+github.com/berty/mobile v0.0.8/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=


### PR DESCRIPTION
Similar to https://github.com/berty/berty/pull/4445, bump the gomobile version to get the latest bug fixes.
